### PR TITLE
[temp] make Ombi v4 text readable

### DIFF
--- a/CSS/themes/ombi/organizr-dark.css
+++ b/CSS/themes/ombi/organizr-dark.css
@@ -21,4 +21,5 @@
   --loading-bar: #2cabe3; 
   --accent-color: #2cabe3;
   --label-color: #2cabe3;
+  --text: #ddd;
 }


### PR DESCRIPTION
I was not able to see how you setup text colors in other themes, but seems this one was referring to a non-existent `--text` variable. I added a placeholder until this theme is polished by you