### PR TITLE
Duplicacy fixes

### DIFF
--- a/CSS/themes/duplicacy/duplicacy-base.css
+++ b/CSS/themes/duplicacy/duplicacy-base.css
@@ -84,6 +84,27 @@ body,
     box-shadow: none;
 }
 
+/* PLACEHOLDER TEXT */
+::placeholder {
+    color: var(--text) !important;
+    opacity: .5!important;
+}
+
+:-moz-placeholder {
+    color: var(--text) !important;
+    opacity: .5!important;
+}
+
+:-ms-input-placeholder {
+    color: var(--text) !important;
+    opacity: .5!important;
+}
+
+::-webkit-input-placeholder {
+    color: var(--text) !important;
+    opacity: .5;
+}
+
 /* CARDS */
 .card {
     background: rgb(255 255 255 / 8%);

--- a/CSS/themes/duplicacy/duplicacy-base.css
+++ b/CSS/themes/duplicacy/duplicacy-base.css
@@ -131,12 +131,12 @@ body,
 }
 
 .sidebar .nav li.active>a:before,
-.off-canvas-sidebar .nav li.active>a:before,
 .sidebar .nav li.active>a:after {
     border-right: 17px solid var(--accent-color);
 }
 
 @media (min-width: 992px) {
+    .off-canvas-sidebar .nav li.active>a:before,
     .off-canvas-sidebar .nav li.active>a:after {
         border-right: 17px solid var(--accent-color);
     }
@@ -289,6 +289,12 @@ textarea {
     color: var(--button-color);
 }
 
+.btn-primary:focus {
+    border-color: var(--button-color);
+    color: var(--button-color);
+    background-color: transparent;
+}
+
 .btn-primary:hover {
     border-color: var(--button-color-hover);
     color: var(--text-hover);
@@ -358,9 +364,12 @@ div>div>div.modal-footer>button.btn.btn-default.pull-left:hover,
 .table>thead>tr.active>th,
 .table>thead>tr>td.active,
 .table>thead>tr>th.active,
-.fixed-header th,
 .row-clickable.active {
     background-color: rgb(0 0 0 / 25%);
+}
+
+.fixed-header th {
+    background: var(--main-bg-color);
 }
 
 .table thead tr>th,
@@ -404,6 +413,7 @@ color: var(--text);
         box-shadow: 0 0 10px 0px #000000;
         background: var(--modal-bg-color);
     }
+    .off-canvas-sidebar .nav li.active>a:before,
     .off-canvas-sidebar .nav > li.active > a:after {
         border-left: 17px solid var(--accent-color);
     }


### PR DESCRIPTION
Fix the active tab indicator for the mobile sidebar, remove transparency on the pinned table header in restore window, *try* to fix the initial state of the "OK" button when trying to mark a job as parallel in the schedule window.

Placeholder text is not being differentiated from normal text in input boxes, so that's still pending along with the Schedule Graph navpills. Rest seems to look amazing to me now (up to you if you want to try to handle the multiple layers of cards on Schedule/Backup tabs, though I think it still looks good).