### PR TITLE
Added small improvements to queue table and progress indicators for SABnzbd

### DIFF
--- a/CSS/themes/sabnzbd/sabnzbd-base.css
+++ b/CSS/themes/sabnzbd/sabnzbd-base.css
@@ -644,3 +644,11 @@ label {
 #content a, #content a:hover, #content a:active, #content a:visited, #serverResponse {
   color: #eee;
 }
+
+/* interface configuration */
+#modal-options .table-server-connections th {
+  border-left: none;
+}
+#modal-options .table-server-connections th:last-child {
+  border-right: none;
+}

--- a/CSS/themes/sabnzbd/sabnzbd-base.css
+++ b/CSS/themes/sabnzbd/sabnzbd-base.css
@@ -25,8 +25,8 @@ body {
   font-size: 1.4em !important;
   color: white;
 }
-  /* Scrollbar */  
-  @media only screen and (min-width: 768px) {  
+  /* Scrollbar */
+  @media only screen and (min-width: 768px) {
     html {
         height: 100%;
         width: 100%;
@@ -105,6 +105,12 @@ body {
 }
 .caret {
   border-top-color: white !important;
+}
+svg.peity polygon {
+  fill: var(--nav-button-color) !important;
+}
+svg.peity polyline {
+  stroke: var(--nav-button-color) !important;
 }
 
 /* BUTTONS */
@@ -300,6 +306,20 @@ tbody>tr:last-child td {
 .table-messages .table-messages-remove {
   border-bottom: 1px solid transparent!important;
   background: rgba(255, 255, 255, 0.25);
+}
+.progress {
+  background-color: transparent !important;
+  box-shadow: none !important;
+  -webkit-box-shadow: none !important;
+}
+.progress-bar strong {
+  color: hsla(0,0%,100%,.7) !important;
+}
+.progress-bar + span{
+  color: hsla(0,0%,100%,.7) !important;
+}
+.progress-bar-info {
+  background-color: var(--nav-button-color);
 }
 
 

--- a/CSS/themes/sabnzbd/sabnzbd-base.css
+++ b/CSS/themes/sabnzbd/sabnzbd-base.css
@@ -321,6 +321,15 @@ tbody>tr:last-child td {
 .progress-bar-info {
   background-color: var(--nav-button-color);
 }
+.glyphicon-compressed:before{
+  color: #888;
+}
+.direct-unpack span{
+  color: #888;
+}
+.processing-download > div {
+  background-color: #888;
+}
 
 
 .multioperations-selector {


### PR DESCRIPTION
**Before:**
![108609193-b27d2280-73cc-11eb-9987-2dcefee19774](https://user-images.githubusercontent.com/12700450/108915583-62e96180-762d-11eb-85c2-8323ba905de9.png)


As you can see the progress bar in the queue table is not themed and the progress indicators are still the default green color.

**After:**
![108609192-aee99b80-73cc-11eb-8ad6-4537b7c22eca](https://user-images.githubusercontent.com/12700450/108915595-67ae1580-762d-11eb-917e-f2fb5035b67e.png)


I added added some transparency in the queue to ensure consistent colors in the table and I added the default navbar button colors to the progress indicators for consistency.
