### PR TITLE
Updating for Sab servers page date boxes

### DIFF
--- a/CSS/themes/sabnzbd/sabnzbd-base.css
+++ b/CSS/themes/sabnzbd/sabnzbd-base.css
@@ -477,14 +477,14 @@ table {
 }
 
 /*Input*/
-input[type="text"], input[type="email"], input[type="url"], input[type="number"], input[type="password"], textarea, select {
+input[type="text"], input[type="email"], input[type="url"], input[type="number"], input[type="password"], input[type="date"], textarea, select {
   border: none;
   background-color: rgba(255, 255, 255, 0.25);
   border-radius: 3px !important;
   color: #fff !important;
   outline: none;
 }
-input[type="text"]:focus, input[type="email"]:focus, input[type="url"]:focus, input[type="number"]:focus, input[type="password"]:focus, textarea:focus, select:focus {
+input[type="text"]:focus, input[type="email"]:focus, input[type="url"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="date"]:focus, textarea:focus, select:focus {
   border: none;
   background-color: rgb(25, 26, 28);
   border-radius: 3px !important;


### PR DESCRIPTION

Sab added date boxes for metric range selection and account expiration. This adds a selector for "date" type boxes to regular and focused, as only hovered boxes were being styled before.

## Before
![firefox-2021-03-09-1615344483](https://user-images.githubusercontent.com/767190/110568840-a8c02280-8121-11eb-8b45-2a0af994fc66.png)

## After
![firefox-2021-03-09-1615344593](https://user-images.githubusercontent.com/767190/110568951-d3aa7680-8121-11eb-8302-e6ae4c35d11a.png)

