### PR TITLE
Fix for overlapping text

### DIFF
--- a/CSS/themes/deluge/deluge-base.css
+++ b/CSS/themes/deluge/deluge-base.css
@@ -1409,7 +1409,7 @@
   
   .x-panel-tbar .x-btn-text {
       height: 24px !important;
-      color: rgb(0,0,0,0);
+      color: rgb(0,0,0,0) !important;
   }
   
   .x-panel-tbar .x-toolbar .xtb-sep {


### PR DESCRIPTION
Fix for overlapping visible text before login. Copied from HalianElf's fix:
[https://github.com/HalianElf/Deluge-Dark/commit/d480db2def5e6b283f219ec7773b07149c5b155e](url)


## Thank you for the PR!

### Please remember to add a before and after screenshot(s) on any css changes! 
