### PR TITLE
Fix for overlapping text

### DIFF
--- a/CSS/themes/deluge/deluge-base.css
+++ b/CSS/themes/deluge/deluge-base.css
@@ -1409,7 +1409,7 @@
   
   .x-panel-tbar .x-btn-text {
       height: 24px !important;
-      color: rgb(0,0,0,0);
+      color: rgb(0,0,0,0) !important;
   }
   
   .x-panel-tbar .x-toolbar .xtb-sep {


### PR DESCRIPTION
Fix for overlapping text visible before login. Copied from:
[https://github.com/HalianElf/Deluge-Dark/issues/1](url)

![before](https://user-images.githubusercontent.com/38113357/116536715-91154700-a8e5-11eb-9a32-646474b7f8bf.png)
![after](https://user-images.githubusercontent.com/38113357/116536736-970b2800-a8e5-11eb-84fb-ae52e301230e.png)


## Thank you for the PR!

### Please remember to add a before and after screenshot(s) on any css changes! 
