### PR TITLE
Plex poster unwatched

### DIFF
--- a/CSS/themes/bazarr/bazarr-base.css
+++ b/CSS/themes/bazarr/bazarr-base.css
@@ -257,10 +257,6 @@ a:hover {
 
 }
 
-.bg-light {
-    background-color: var(--main-bg-color) !important;
-}
-
 .card {
     background-color: rgba(0, 0, 0, .45);
     box-shadow: 0 0 10px 1px #000000;

--- a/CSS/themes/plex/aquamarine.css
+++ b/CSS/themes/plex/aquamarine.css
@@ -26,5 +26,5 @@
   --accent-color-hover: #fff;
   --link-color: #0ed2bf;
   --link-color-hover: #FFF;
-  --poster-unwatched: #00d374;
+  --poster-unwatched: #15D5C2;
 }

--- a/CSS/themes/plex/dark.css
+++ b/CSS/themes/plex/dark.css
@@ -26,5 +26,5 @@
   --accent-color-hover: #ffffff73;
   --link-color: #e5a00d;
   --link-color-hover: #FFF;
-  --poster-unwatched: #00d374;
+  --poster-unwatched: #e5a00d;
 }

--- a/CSS/themes/plex/hotline.css
+++ b/CSS/themes/plex/hotline.css
@@ -26,5 +26,5 @@
   --accent-color-hover: rgba(255, 255, 255, .5);
   --link-color: #f44336;
   --link-color-hover: #FFF;
-  --poster-unwatched: #00d374;
+  --poster-unwatched: #FB3122;
 }


### PR DESCRIPTION
The themes organizr-dark and space-gray have specific colors for "poster unwatched":
---
![image](https://user-images.githubusercontent.com/29847057/118013541-2125a880-b34a-11eb-94c6-8be36b35459a.png)
![image](https://user-images.githubusercontent.com/29847057/118013622-369ad280-b34a-11eb-9fa0-ade73353fb04.png)
---

while the rest have a (IMO) jarring color green which does not match the respective theme:
---
![image](https://user-images.githubusercontent.com/29847057/118013875-7f528b80-b34a-11eb-8f4a-b2ceb359a6ef.png)
![image](https://user-images.githubusercontent.com/29847057/118013921-8ed1d480-b34a-11eb-8974-25cf62e49671.png)
![image](https://user-images.githubusercontent.com/29847057/118014041-b163ed80-b34a-11eb-9306-5a9a4b4636b3.png)
---

After:
---
![image](https://user-images.githubusercontent.com/29847057/118014244-e4a67c80-b34a-11eb-994f-5f5b5a5a5a3d.png)
![image](https://user-images.githubusercontent.com/29847057/118014342-030c7800-b34b-11eb-9bb6-c188921c603c.png)
![image](https://user-images.githubusercontent.com/29847057/118014403-161f4800-b34b-11eb-99ea-404d4b2cfd38.png)
---

## Thank you for the PR!

### Please remember to add a before and after screenshot(s) on any css changes! 
