### PR TITLE
Fix for alert-info modal in jackett

### DIFF
--- a/CSS/themes/jackett/jackett-base.css
+++ b/CSS/themes/jackett/jackett-base.css
@@ -215,6 +215,6 @@ fieldset[disabled] .form-control {
 
 .alert-info {
     color: #ffffff;
-    background-color: var(--modal-bg-color);
+    background: var(--modal-bg-color);
     border-color: transparent;
 }


### PR DESCRIPTION
The .alert-info didn't have a background because the `background-color` property should've been `background` instead

Before:
![image](https://user-images.githubusercontent.com/64543651/122604947-09db8880-d077-11eb-9700-e8b0d1aaccea.png)

After:
![image](https://user-images.githubusercontent.com/64543651/122604902-f9c3a900-d076-11eb-999a-a6e440112840.png)

