### PR TITLE
Radarr: fixed discover poster background color

### DIFF
--- a/CSS/themes/radarr/radarr-base.css
+++ b/CSS/themes/radarr/radarr-base.css
@@ -640,8 +640,10 @@ a:hover {
     text-decoration: none;
 }
 
-.DiscoverMoviePoster-title-1owri {
-    background-color: var(--accent-color);
+[class*="DiscoverMoviePoster-title-"],
+[class*="DiscoverMoviePosterInfo-info-"] {
+    background-color: rgba(255, 255, 255, 0.08);
+    color: var(--text);
 }
 
 /*Title*/

--- a/CSS/themes/radarr/radarr-base.css
+++ b/CSS/themes/radarr/radarr-base.css
@@ -640,6 +640,10 @@ a:hover {
     text-decoration: none;
 }
 
+.DiscoverMoviePoster-title-1owri {
+    background-color: var(--accent-color);
+}
+
 /*Title*/
 [class*="AddListMovieOverview-link-"] {
     color: var(--text);


### PR DESCRIPTION
This is a fix for issue #220.

Before:
![before](https://user-images.githubusercontent.com/21286973/123657695-a4199a00-d7f6-11eb-9815-e289f996f348.png)

After:
![after](https://user-images.githubusercontent.com/21286973/123657724-ab40a800-d7f6-11eb-8843-020690080d5e.png)

