### PR TITLE
Fix prowlarr organizr-dark

### DIFF
--- a/CSS/themes/prowlarr/organizr-dark.css
+++ b/CSS/themes/prowlarr/organizr-dark.css
@@ -13,7 +13,7 @@
 
 /* prowlarr ORGANIZR-DARK THEME */
 @import url(https://theme-park.dev/CSS/themes/prowlarr/prowlarr-base.css);
-@import url(https://theme-park.dev/CSS/variables/prganizr-dark.css);
+@import url(https://theme-park.dev/CSS/variables/organizr-dark.css);
 
 /* APP VARS */
 :root {


### PR DESCRIPTION
You put a `p` instead of an `o` for `organizr` so it broke the theme.