### PR TITLE
Fix new index.html path for deluge

### DIFF
--- a/docker-mods/deluge/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/deluge/root/etc/cont-init.d/98-themepark
@@ -34,12 +34,13 @@ if [[ -z ${TP_THEME} ]]; then
 fi
 
 # Adding stylesheets
-if ! grep -q "${TP_DOMAIN}/css/base" /usr/lib/python3/dist-packages/deluge/ui/web/index.html; then
+INDEX_HTML='/usr/lib/python3.10/site-packages/deluge/ui/web/index.html'
+if ! grep -q "${TP_DOMAIN}/css/base" "$INDEX_HTML"; then
     echo '---------------------------'
     echo '|  Adding the stylesheet  |'
     echo '---------------------------'
-    sed -i "s/<\/head>/<link rel='stylesheet' href='https:\/\/${TP_DOMAIN}\/css\/base\/deluge\/deluge-base.css'><\/head> /g" /usr/lib/python3/dist-packages/deluge/ui/web/index.html
-    sed -i "s/<\/head>/<link rel='stylesheet' href='https:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'><\/head> /g" /usr/lib/python3/dist-packages/deluge/ui/web/index.html
+    sed -i "s/<\/head>/<link rel='stylesheet' href='https:\/\/${TP_DOMAIN}\/css\/base\/deluge\/deluge-base.css'><\/head> /g" "$INDEX_HTML"
+    sed -i "s/<\/head>/<link rel='stylesheet' href='https:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'><\/head> /g" "$INDEX_HTML"
     printf 'Stylesheet set to %s\n' "${TP_THEME}
     "
 fi


### PR DESCRIPTION
Theme was broken, now it is fixed :)

<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Path to `index.html` file must have changed recently in the linuxserver.io deluge container, so the theme would never be applied. This fixes the path so the theme works again.

## Benefits of this PR and context:
Otherwise, deluge theme will not work

## How Has This Been Tested?
Made the change locally in my container and restarted. It worked

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->