### PR TITLE
fix(init): remove build-deps

### DIFF
--- a/docker/root/etc/cont-init.d/50-config
+++ b/docker/root/etc/cont-init.d/50-config
@@ -41,6 +41,10 @@ cp /app/themepark/CNAME /config/www
 echo 'Creating CSS files'
 python3 /config/www/themes.py
 
+# remove build deps
+# to reduce attack surface
+apk del build-dependencies
+
 # permissions
 chown -R abc:abc \
     /config


### PR DESCRIPTION
 - [X] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:
Remove build-depds after build-script is executed by Python.  This reduces the attack surface of the container, as leaving python3 installed in a rootfull container is a risk after the script is executed & python no longer needed.

## Benefits of this PR and context:
Increase of security in docker container

## How Has This Been Tested?
Build locally and ensured functionality is retained & python3 no longer executable

## Source / References: