### PR TITLE
Override RSS Header Background Image (RuTorrent)

### DIFF
--- a/css/base/rutorrent/rutorrent-base.css
+++ b/css/base/rutorrent/rutorrent-base.css
@@ -1800,3 +1800,7 @@ div#dlgEditRules div.dlg-header {
     background: var(--transparency-dark-10);
     color: var(--text);
 }
+
+div#dlgEditFilters div.dlg-header{
+    background-image:none;
+}


### PR DESCRIPTION
After latest release, RSS window header shows a tiling image caused by transparent background styling. I looked at other headers and for some reason this is the only one with a tiling image. This change makes RSS header match all other modal window headers.

Before: https://i.imgur.com/Sk1Gs0a.png
After: https://i.imgur.com/AgSObmX.png


