### PR TITLE
fix pihole checkboxes having wrong color

### DIFF
--- a/css/base/pihole/pihole-base.css
+++ b/css/base/pihole/pihole-base.css
@@ -499,6 +499,11 @@
       border-color: var(--button-color) !important;
   }
 
+  [class*=icheck-]>input:first-child:checked+input[type=hidden]+label::after,
+  [class*=icheck-]>input:first-child:checked+label::after {
+      border-color: var(--button-text);
+  }
+
   /* Input */
   input,
   .form-control,


### PR DESCRIPTION

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications
------------------------------

## Bug fixes

Fixes checkboxes and radio buttons using wrong color
| before | after |
|:---:|:---:|
|![before](https://user-images.githubusercontent.com/18114966/175333359-b7946466-d546-4f56-a72a-94c9484905c9.png)| ![after](https://user-images.githubusercontent.com/18114966/175333389-76e5e12d-2e36-402d-b721-dc90bde4d620.png) |

## Description:
Selector copied from pihole's css.

## How Has This Been Tested?
Tested via browser devtools with nord theme installed and using pihole's `Pi-hole midnight theme (dark)` theme.