### PR TITLE
Pihole network table row backgrounds fix

### DIFF
--- a/css/base/pihole/pihole-base.css
+++ b/css/base/pihole/pihole-base.css
@@ -411,11 +411,11 @@
   }
 
   /* Network */
-  .table-striped>tbody>tr:nth-of-type(odd) {
+  .table-striped>tbody>tr:nth-of-type(odd):not(#network-details .table-striped>tbody>tr:nth-of-type(odd)) {
       background: var(--transparency-dark-25) !important;
   }
 
-  .table-striped>tbody>tr:nth-of-type(even) {
+  .table-striped>tbody>tr:nth-of-type(even):not(#network-details .table-striped>tbody>tr:nth-of-type(even)) {
       background: var(--transparency-dark-50) !important;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

- When submitting bugfixes please show a before and after screenshot of the fix, and a description of what the fix does.

## Description:
Removes the table row background color styling in network details tab since it provides informational value to the user. Other tables are kept untouched by this change.

Before:
<img width="1024" alt="before" src="https://user-images.githubusercontent.com/63553146/230732645-200f9938-0616-421b-8f64-6bfc8f35ba31.png">

After:
<img width="1031" alt="after" src="https://user-images.githubusercontent.com/63553146/230732662-3b98c5dd-82b7-45e1-a646-c0b08d09158d.png">



## Benefits of this PR and context:
It fixes the intended behaviour of the app which was broken by the theme.
<img width="1015" alt="context" src="https://user-images.githubusercontent.com/63553146/230732851-6add317b-e7a0-445e-bce4-e81e45838cc6.png">


## How Has This Been Tested?
Inline CSS browser

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->