### PR TITLE
Load stylesheets in the same order as when they were in the head

### DIFF
--- a/docker-mods/lidarr/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/lidarr/root/etc/cont-init.d/98-themepark
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/lidarr\/lidarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/lidarr\/lidarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/lidarr/lidarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/lidarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/lidarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/lidarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/lidarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/lidarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/lidarr\/lidarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/lidarr\/lidarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/sonarr/sonarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/lidarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/lidarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/sonarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/prowlarr/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/prowlarr/root/etc/cont-init.d/98-themepark
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/prowlarr\/prowlarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/prowlarr\/prowlarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/prowlarr/prowlarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/prowlarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/prowlarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/prowlarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/prowlarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/prowlarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/prowlarr\/prowlarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/prowlarr\/prowlarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/prowlarr/prowlarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/prowlarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/prowlarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/prowlarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/radarr/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/radarr/root/etc/cont-init.d/98-themepark
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/radarr\/radarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/radarr\/radarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/radarr/radarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/radarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/radarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/radarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/radarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/radarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/radarr\/radarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/radarr\/radarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/radarr/radarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/radarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/radarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/radarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/readarr/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/readarr/root/etc/cont-init.d/98-themepark
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/readarr\/readarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/readarr\/readarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/readarr/readarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/readarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/readarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/readarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/readarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/readarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body>/<link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/readarr\/readarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/readarr\/readarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/readarr/readarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/readarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/readarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/readarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/sonarr/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/sonarr/root/etc/cont-init.d/98-themepark
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/sonarr\/sonarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/sonarr\/sonarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/sonarr/sonarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/sonarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/sonarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/sonarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/sonarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/sonarr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/sonarr\/sonarr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/sonarr\/sonarr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/sonarr/sonarr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/sonarr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/sonarr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/sonarr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/whisparr/root/etc/cont-init.d/98-themepark
+++ b/docker-mods/whisparr/root/etc/cont-init.d/98-themepark
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/whisparr\/whisparr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/whisparr\/whisparr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/whisparr/whisparr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/whisparr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/whisparr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/whisparr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi

--- a/docker-mods/whisparr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/whisparr/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -50,18 +50,22 @@ fi
 # Adding stylesheets
 if ! grep -q "${TP_DOMAIN}/css/base" "${APP_FILEPATH}"; then
     echo '---------------------------'
-    echo '|  Adding the stylesheet  |'
+    echo '|  Adding the stylesheets |'
     echo '---------------------------'
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/whisparr\/whisparr-base.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${APP_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/base\/whisparr\/whisparr-base.css'> /g" "${LOGIN_FILEPATH}"
-    sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/${THEME_TYPE}\/${TP_THEME}.css'> /g" "${LOGIN_FILEPATH}"
+
+    url_base="${TP_SCHEME}://${TP_DOMAIN}"
+    sheets="<link rel='stylesheet' href='${url_base}/css/base/whisparr/whisparr-base.css'>"
+    sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/${THEME_TYPE}/${TP_THEME}.css'>"
     printf 'Stylesheet set to %s\n' "${TP_THEME}"
+
     if [[ -n ${TP_ADDON} ]]; then
         for addon in $(echo "$TP_ADDON" | tr "|" " "); do
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/whisparr\/${addon}\/${addon}.css'> /g" "${APP_FILEPATH}"
-        sed -i "s/<body>/<body><link rel='stylesheet' href='${TP_SCHEME}:\/\/${TP_DOMAIN}\/css\/addons\/whisparr\/${addon}\/${addon}.css'> /g" "${LOGIN_FILEPATH}"
+        sheets="${sheets} <link rel='stylesheet' href='${url_base}/css/addons/whisparr/${addon}/${addon}.css'>"
         printf 'Added custom addon: %s\n\n' "${addon}"
         done
     fi
+
+    sed -i "s!<body>!<body>${sheets}!g" "${APP_FILEPATH}"
+    sed -i "s!<body>!<body>${sheets}!g" "${LOGIN_FILEPATH}"
+    printf 'Stylesheets inserted.'
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

Closes #502 

## Description:

When the fix was made for *arr apps to load the stylesheets into the HTML body instead of the header, they accidentally started getting loaded in backwards order compared to the order they'd been loaded in before.  This meant that values in theme stylesheets were being overridden by values in base stylesheets, because the base sheets were loaded after the theme.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR ensures that the stylesheets are loaded in the same order they were loaded in before the move out of `<head>`.  That should help guarantee that anything that was working prior to the move will still work after.

Thinking about it, I actually think it might make more sense to load the app's base CSS, then any addons, and then the theme CSS last, but since that's a potentially breaking change I stuck with making sure they get loaded in the same order they used to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I built the sonarr mod locally with the new changes and loaded it in my LSIO sonarr container and checked that the stylesheets are getting loaded in the expected order.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->