### PR TITLE
CSS edge case fixes for sabnzbd-base.css

### DIFF
--- a/css/base/sabnzbd/sabnzbd-base.css
+++ b/css/base/sabnzbd/sabnzbd-base.css
@@ -508,15 +508,20 @@ td.delete .dropdown>a .caret {
 
 fieldset>div,
 .history-table>tbody>tr:nth-of-type(odd),
+.table-messages>tbody>tr:nth-of-type(odd),
 .table-striped>tbody>tr:nth-of-type(odd) {
   background: var(--transparency-dark-25) !important;
 }
 
 fieldset>div.even,
-  /* fieldset>div:nth-of-type(odd), */
 .history-table>tbody>tr:nth-of-type(even),
+.table-messages>tbody>tr:nth-of-type(even),
 .table-striped>tbody>tr:nth-of-type(even) {
   background: transparent !important;
+}
+
+.table-messages-remove {
+  background: var(--transparency-dark-05) !important;
 }
 
 tbody.no-downloads tr td {

--- a/css/base/sabnzbd/sabnzbd-base.css
+++ b/css/base/sabnzbd/sabnzbd-base.css
@@ -688,14 +688,14 @@ tr td.row-extra-text,
 
 .form-control {
   color: var(--text-hover);
-  background: var(--transparency-dark-25);
+  background: var(--transparency-dark-25) !important;
 }
 
 .form-control:focus {
-  border-color: var(--text-hover);
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  background: #1b1b1b;
+  border-color: var(--text-hover) !important;
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  background: #1b1b1b !important;
 }
 
 /*Tabbed sorting */

--- a/css/base/sabnzbd/sabnzbd-base.css
+++ b/css/base/sabnzbd/sabnzbd-base.css
@@ -858,7 +858,7 @@ input[type="date"],
 textarea,
 select {
   border: none;
-  background: var(--transparency-dark-15);
+  background: var(--transparency-dark-15) !important;
   border-radius: 3px !important;
   color: var(--text-hover) !important;
   outline: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

- Fixed the CSS for the messages table that hides itself when no messages are in the queue
- Fixed the CSS for the form control select input in the modal "Status" display
- Fixed the CSS for a couple of other select inputs throughout the settings page
- Removed a pointless commented line I pushed through in my previous pull request

## Description:
<!--- Describe your changes in detail -->
New to this and overlooked a couple parts of sabnzbd in my last PR. Had some more time to go over it more thoroughly and fix up the last bits.

<!--- Add before and after screenshots of your changes -->
Before Images:
![image](https://github.com/user-attachments/assets/e2538b5a-9c4d-480f-9332-33a2302aedd1)
![image](https://github.com/user-attachments/assets/712f5005-ba45-4d83-bdef-d270bff503ae)
![image](https://github.com/user-attachments/assets/313f98c1-23f9-49f0-96b4-6a986acbbede)

After Images:
![image](https://github.com/user-attachments/assets/2ab336e2-b7d9-49db-8ea6-4b6b62025253)
![image](https://github.com/user-attachments/assets/aabeb98e-2417-4182-9ac8-d3f907f88481)
![image](https://github.com/user-attachments/assets/68daf58f-10af-4196-ad90-5685410c57bd)


## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Better sabnzbd support

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with editing the sabnzbd-base.css file in the Sources of Brave browser inspector.
Once working there I pushed my changes into my local theme-park docker container and was able to pull it through the Stylus extension.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
This is a follow up to https://github.com/themepark-dev/theme.park/pull/680