### PR TITLE
Adding support for Docmost App

### DIFF
--- a/css/base/docmost/docmost-base.css
+++ b/css/base/docmost/docmost-base.css
@@ -1,0 +1,191 @@
+@import url("/css/defaults/placeholders.css");
+@import url("/css/defaults/transparent.css");
+
+:root {
+    --scheme-main-ter: var(--main-bg-color);
+    --text-strong-color: var(--button-text-hover);
+    --border-color: var(--transparency-light-25);
+    --logo-color: rgb(var(--accent-color));
+    --body-background-color: var(--main-bg-color);
+    --border-hover-color: rgb(var(--accent-color));
+    --header-button-color: var(--button-color); /* Docmost overrider --button-color in some fields so I make a copy of --button-color at the start */
+}
+
+* {
+    outline: none;
+}
+
+html,
+body,
+.mantine-Modal-content,
+.mantine-Spotlight-content {
+    background: var(--main-bg-color) !important;
+    background-repeat: repeat, no-repeat;
+    background-attachment: fixed, fixed;
+    background-position: center center, center center;
+    background-size: auto, cover;
+    -webkit-background-size: auto, cover;
+    -moz-background-size: auto, cover;
+    -o-background-size: auto, cover;
+    color: var(--text);
+}
+
+[class^="_header"] .mantine-UnstyledButton-root,
+[class^="_header"] .mantine-Button-root,
+nav .mantine-Group-root .mantine-UnstyledButton-root {
+    background: var(--header-button-color) !important;
+    color: var(--button-text) !important;
+}
+
+[class^="_header"] .mantine-UnstyledButton-root:hover,
+[class^="_header"] .mantine-Button-root:hover,
+nav .mantine-Group-root .mantine-UnstyledButton-root:hover {
+    background: var(--button-color-hover) !important;
+    color: var(--button-text-hover) !important;
+}
+
+header [class^="_link"]:hover,
+nav a.isSelected,
+nav [class^="_actions"] {
+    background: var(--transparency-light-10) !important;
+    color: rgb(var(--accent-color)) !important;
+}
+
+nav a.isSelected:hover,
+nav a:hover,
+nav button:hover,
+nav [class^="_actions"] {
+    background: var(--transparency-dark-25) !important;
+    color: var(--button-text-hover) !important;
+}
+
+.mantine-Tabs-tab {
+    border-color: rgb(var(--accent-color)) ;
+}
+
+header,
+.mantine-Group-root,
+.mantine-Divider-root,
+.mantine-Select-input,
+.mantine-Switch-trackLabel,
+.mantine-Paper-root,
+.mantine-Table-table,
+.mantine-TextInput-input,
+.mantine-Menu-dropdown,
+.mantine-Menu-divider,
+.mantine-Tabs-root .mantine-Table-tr,
+nav .mantine-Group-root .mantine-ActionIcon-root,
+nav [class^="_section"] {
+    border-color: var(--transparency-light-10) !important;
+}
+
+.mantine-Badge-root {
+    background: rgb(var(--accent-color));
+    color: var(--button-text);
+}
+
+[class^="_editor"] .ProseMirror,
+[class^="_card"] .mantine-Card-section {
+    background: transparent;
+}
+
+svg,
+nav a.isSelected:hover svg {
+    stroke: rgb(var(--accent-color));
+}
+
+[class^="_header"] .mantine-UnstyledButton-root svg,
+nav .mantine-Group-root .mantine-UnstyledButton-root svg {
+    stroke: var(--button-text);
+}
+
+.mantine-Menu-dropdown,
+.mantine-Popover-dropdown {
+    background: var(--drop-down-menu-bg);
+    color: var(--text);
+}
+
+label:has(input:checked) .mantine-Switch-track {
+    background: rgb(var(--accent-color));
+    color: var(--button-text);
+}
+
+.mantine-Menu-item:hover,
+.mantine-SegmentedControl-indicator {
+    background: var(--transparency-light-10);
+    color: var(--text-hover);
+}
+
+a[class*="_activeButton"],
+a[class^="_link"][data-active] {
+    background: var(--transparency-light-10) !important;
+    color: var(--text-hover) !important;
+}
+
+[class^="_header"],
+.mantine-Table-tr:hover,
+.mantine-Tabs-tab:hover{
+    background: var(--transparency-dark-10);
+    color: var(--text);
+}
+
+.mantine-SegmentedControl-root,
+[class^="_card"],
+.mantine-Table-th,
+.mantine-Paper-root {
+    background: var(--transparency-dark-25);
+    color: var(--text);
+}
+
+header,
+nav,
+[class^="_editor"] .tableWrapper tr th,
+.mantine-Input-input,
+.mantine-Table-td .mantine-Button-root,
+.mantine-AppShell-aside{
+    background: var(--transparency-dark-25) !important;
+    color: var(--text) !important;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+section header,
+.menu-label,
+.mantine-Menu-label {
+    color: var(--text-hover) !important;
+}
+
+.mantine-Input-input,
+a[class^="_link"],
+a[class^="_link"][data-active],
+.mantine-SegmentedControl-innerLabel,
+.mantine-Menu-item,
+nav * {
+    color: var(--text);
+}
+
+a.mantine-Anchor-root {
+    color: var(--text) !important; /* Replace with your desired color */
+}
+
+.mantine-Alert-root {
+    background: rgb(var(--accent-color));
+}
+
+.mantine-Alert-message {
+    color: var(--text-hover);
+}
+
+.mantine-Alert-root svg {
+    stroke: var(--text-hover);
+}
+
+a[class^="_link"][data-active] span:hover {
+    background: transparent !important;
+    color: inherit;
+}


### PR DESCRIPTION
Create docmost-base.css to add support for the Docmost app

<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Did my best to add full support for Docmost and all of its pages.
Used plex.css as the template to more naturally match colors to different parts.
A lot of buttons in the app are color coded without enough css attributes to hook into and see one type over another so those have been left for now.
I also did my best to account for the user changing the default theme in the app. Themes should work mostly the same for both Light and Dark mode.

I'm not sure what all is required for submitting something like this so just let me know if I missed anything or more information is needed. 
Thanks!

<!--- Add before and after screenshots of your changes -->
Before:
![image](https://github.com/user-attachments/assets/fc946a9e-9c7b-420a-9058-e07ef5f2a853)
![image](https://github.com/user-attachments/assets/7b75199f-14b6-4cca-9f87-4178057a3f2a)

After:
![image](https://github.com/user-attachments/assets/98fc54c9-2d07-4afd-bac4-9bd48e795b79)
![image](https://github.com/user-attachments/assets/e07d30c0-a145-4e6e-9657-bae32a2e6727)
![image](https://github.com/user-attachments/assets/f1eeb2e8-f76e-46d0-bc07-1aad2f79c936)
![image](https://github.com/user-attachments/assets/e6debe8a-0214-44dc-a99c-a20cc2e9a5c3)
![image](https://github.com/user-attachments/assets/37079519-a7de-422c-b93f-f1f9e280c03a)
![image](https://github.com/user-attachments/assets/fb2dc599-f7f3-4ba1-b5eb-a966b2bf035c)

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
More apps are good and I use Docmost regularly and will do my best to keep it updated if the theming breaks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Using a self hosted instance of theme.park with the Stylus chrome app to inject the css.
Flipped between plex.css, hotline.css, and a custom community theme I made for myself.
<!--- Include details of your testing environment, and the tests you ran to -->
Just went through and clicked on everything I could find to make sure the css is applied to every page, modal, and element in the app.
<!--- see how your change affects other areas of the code, etc. -->
Everything is contained in the base.css file so shouldn't effect any functionality for anything else.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->