### PR TITLE
Catpuccin --text-muted var fix

### DIFF
--- a/css/community-theme-options/catppuccin-frappe.css
+++ b/css/community-theme-options/catppuccin-frappe.css
@@ -20,7 +20,7 @@
 
   --text: #c6d0f5;
   --text-hover: var(--text);
-  --text-muted: a5adce;
+  --text-muted: #a5adce;
 
   /* Specials */
   --arr-queue-color: #a6d189; /* Servarr apps + Bazarr */

--- a/css/community-theme-options/catppuccin-latte.css
+++ b/css/community-theme-options/catppuccin-latte.css
@@ -20,7 +20,7 @@
 
   --text: #4c4f69;
   --text-hover: var(--text);
-  --text-muted: 6c6f85;
+  --text-muted: #6c6f85;
 
   /* Specials */
   --arr-queue-color: #40a02b; /* Servarr apps + Bazarr */

--- a/css/community-theme-options/catppuccin-macchiato.css
+++ b/css/community-theme-options/catppuccin-macchiato.css
@@ -20,7 +20,7 @@
 
   --text: #cad3f5;
   --text-hover: var(--text);
-  --text-muted: a5adcb;
+  --text-muted: #a5adcb;
 
   /* Specials */
   --arr-queue-color: #a6da95; /* Servarr apps + Bazarr */

--- a/css/community-theme-options/catppuccin-mocha.css
+++ b/css/community-theme-options/catppuccin-mocha.css
@@ -20,7 +20,7 @@
 
   --text: #cdd6f4;
   --text-hover: var(--text);
-  --text-muted: a6adc8;
+  --text-muted: #a6adc8;
 
   /* Specials */
   --arr-queue-color: #a6e3a1; /* Servarr apps + Bazarr */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- [x] PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

- When submitting bugfixes please show a before and after screenshot of the fix, and a description of what the fix does.

## Description:
<!--- Describe your changes in detail -->
<!--- Add before and after screenshots of your changes -->
- Added # in front of --text-muted vars in catppuccin themes.
- The --text-muted vars for the catpuccin themes are missing a #, meaning browsers don't see them as colours and they default to inheriting their parent colour. This effectively means text objects can be either incorrectly styled or unstyled.
- You may have to look closely, but you can see the issue in the screenshots below. The text in the table under each attribute (such as 'Aliases: jpegphoto') has its colour set to --text-muted, but is not receiving that colour in the catpuccin themes. In the after screenshots, the # has been added and the muted text works.

### Themes Before Fix
<img width="1903" height="967" alt="frappe-before" src="https://github.com/user-attachments/assets/f3f051ea-a4e4-4b2b-bc93-19e06ee9ba8a" />
<img width="1903" height="967" alt="latte-before" src="https://github.com/user-attachments/assets/b915e360-1298-495f-8c8f-064ef55891ce" />

### Themes After Fix
<img width="1903" height="967" alt="frappe-after" src="https://github.com/user-attachments/assets/4637bb8b-f32c-422f-80ca-afc91a845016" />
<img width="1903" height="966" alt="latte-after" src="https://github.com/user-attachments/assets/2a848107-c93f-4923-b338-556057e9ea2b" />



## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
- Adding the # fixes this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested theme with fix on multiple apps and catppuccin variations.