### PR TITLE
Set SABnzbd graph color to accent color

### DIFF
--- a/css/base/sabnzbd/sabnzbd-base.css
+++ b/css/base/sabnzbd/sabnzbd-base.css
@@ -262,11 +262,11 @@ hr {
 }
 
 svg.peity polygon {
-  fill: var(--button-color) !important;
+  fill: rgb(var(--accent-color)) !important;
 }
 
 svg.peity polyline {
-  stroke: var(--button-color) !important;
+  stroke: rgb(var(--accent-color)) !important;
 }
 
 .rss-icon-svg {


### PR DESCRIPTION
Closes #712

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

Changes the download graph color to `--accent-color`. In practice, this makes the download graph match the colors of the buttons on the right of the navbar and the download limiting slider. In the normal SABnzbd theme, the graph and the slider are the same colors. See #712 for more information.

Before:
<img width="2940" height="876" alt="CleanShot 2026-01-18 at 01 14 20@2x" src="https://github.com/user-attachments/assets/baa93d90-aabb-431a-8082-6b7902cab5be" />

After:
<img width="2940" height="1116" alt="CleanShot 2026-01-18 at 01 22 48@2x" src="https://github.com/user-attachments/assets/00ef5cd9-100d-4dbb-b0f7-b62255513707" />

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
See #712, but the gist is that this makes the theme closer to the normal SABnzbd theme in terms of what colors are used where. Also fixes the Catppuccin themes entirely, as the background and foreground of the graph are the same with how it currently is.

## How Has This Been Tested?
Stylus extension manually copying the CSS files. Only looked at catppuccin-mocha, however this shouldn't negatively affect other themes since the graph will match the buttons on the right which already have contrast with the background. 

## Source / References:
#712